### PR TITLE
Update multi patch + query tests

### DIFF
--- a/packages/adapter-tests/src/methods.ts
+++ b/packages/adapter-tests/src/methods.ts
@@ -235,6 +235,23 @@ export default (test: any, app: any, _errors: any, serviceName: string, idProp: 
         }
       });
 
+      test('.update + query + NotFound', async () => {
+        const dave = await service.create({ name: 'Dave' });
+        try {
+          await service.update(
+            dave[idProp],
+            { name: 'UpdatedDave' },
+            { query:  { name: 'NotDave' } }
+          );
+          throw new Error('Should never get here');
+        } catch (error) {
+          assert.strictEqual(error.name, 'NotFound',
+            'Error is a NotFound Feathers error'
+          );
+        }
+        await service.remove(dave[idProp]);
+      });
+
       test('.update + id + query id', async () => {
         const alice = await service.create({
           name: 'Alice',
@@ -362,7 +379,7 @@ export default (test: any, app: any, _errors: any, serviceName: string, idProp: 
 
         assert.strictEqual(data.length, 2, 'returned two entries');
         assert.strictEqual(data[0].age, 2, 'First entry age was updated');
-        assert.strictEqual(data[1].age, 2, 'Sceond entry age was updated');
+        assert.strictEqual(data[1].age, 2, 'Second entry age was updated');
 
         await service.remove(dave[idProp], params);
         await service.remove(david[idProp], params);
@@ -377,6 +394,23 @@ export default (test: any, app: any, _errors: any, serviceName: string, idProp: 
             'Error is a NotFound Feathers error'
           );
         }
+      });
+
+      test('.patch + query + NotFound', async () => {
+        const dave = await service.create({ name: 'Dave' });
+        try {
+          await service.patch(
+            dave[idProp],
+            { name: 'PatchedDave' },
+            { query:  { name: 'NotDave' } }
+          );
+          throw new Error('Should never get here');
+        } catch (error) {
+          assert.strictEqual(error.name, 'NotFound',
+            'Error is a NotFound Feathers error'
+          );
+        }
+        await service.remove(dave[idProp]);
       });
 
       test('.patch + id + query id', async () => {

--- a/packages/adapter-tests/src/methods.ts
+++ b/packages/adapter-tests/src/methods.ts
@@ -351,13 +351,13 @@ export default (test: any, app: any, _errors: any, serviceName: string, idProp: 
 
         assert.strictEqual(data.length, 2, 'returned two entries');
         assert.strictEqual(data[0].age, 2, 'First entry age was updated');
-        assert.strictEqual(data[1].age, 2, 'Sceond entry age was updated');
+        assert.strictEqual(data[1].age, 2, 'Second entry age was updated');
 
-        await service.remove(dave[idProp], params);
-        await service.remove(david[idProp], params);
+        await service.remove(dave[idProp]);
+        await service.remove(david[idProp]);
       });
 
-      test('.patch multi query', async () => {
+      test('.patch multi query same', async () => {
         const service = app.service(serviceName);
         const params = {
           query: { age: { $lt: 10 } }
@@ -381,8 +381,36 @@ export default (test: any, app: any, _errors: any, serviceName: string, idProp: 
         assert.strictEqual(data[0].age, 2, 'First entry age was updated');
         assert.strictEqual(data[1].age, 2, 'Second entry age was updated');
 
-        await service.remove(dave[idProp], params);
-        await service.remove(david[idProp], params);
+        await service.remove(dave[idProp]);
+        await service.remove(david[idProp]);
+      });
+
+      test('.patch multi query changed', async () => {
+        const service = app.service(serviceName);
+        const params = {
+          query: { age: 10 }
+        };
+        const dave = await service.create({
+          name: 'Dave',
+          age: 10,
+          created: true
+        });
+        const david = await service.create({
+          name: 'David',
+          age: 10,
+          created: true
+        });
+
+        const data = await service.patch(null, {
+          age: 2
+        }, params);
+
+        assert.strictEqual(data.length, 2, 'returned two entries');
+        assert.strictEqual(data[0].age, 2, 'First entry age was updated');
+        assert.strictEqual(data[1].age, 2, 'Second entry age was updated');
+
+        await service.remove(dave[idProp]);
+        await service.remove(david[idProp]);
       });
 
       test('.patch + NotFound', async () => {


### PR DESCRIPTION
This PR addresses https://github.com/feathersjs/databases/issues/3 and 1 other use case

There are three new tests added. 

`.update + query + NotFound` and `'.patch + query + NotFound'` tests that if the user passes a valid id but an invalid query that the adapter returns a NotFound

`.patch multi query changed` tests that when a patch with a query changes the data that was originally being queried, that proper results are returned.

You will also notice that I removed the `params` arguments from the tests where we are cleaning up after ourselves like `await service.remove(david[idProp]);`. This is because those original `params` are no longer valid. This went unnoticed in the two test where it was happening because the params did not affect that remove query. But, that would throw an error in `.patch multi query changed'` because there is no one `{ age: 10 }` anymore. Let me know if that makes sense.

I am not quite sure how actually test these.