### PR TITLE
fix: add overloads for `find`

### DIFF
--- a/packages/adapter-commons/src/service.ts
+++ b/packages/adapter-commons/src/service.ts
@@ -156,6 +156,8 @@ export class AdapterService<T = any> implements ServiceMethods<T> {
     }
   }
 
+  find (params: Params & { paginate: false }): Promise<T[]>;
+  find (params?: Params): Promise<Paginated<T>>;
   find (params?: Params): Promise<T[] | Paginated<T>> {
     return callMethod(this, '_find', params);
   }


### PR DESCRIPTION
This adds overloads to the `AdapterService` `find` method so that we can automatically infer the return type based on `params.paginate`.

**Note** that this assumes that all `AdapterService` instances implement pagination **and** have pagination enabled.

If we want to allow disabling pagination in the `AdapterService` options object, we will need to do something fancier or have a `PaginatedAdapterService` that extends the base `AdapterService`

One way to handle the "fancier" option might be to have a discriminated union type for `ServiceOptions` and use a conditional type for determining the return type, but my first go at that looks... messy.

```typescript
interface BaseServiceOptions {
  events: string[];
  multi: boolean|string[];
  id: string;
  whitelist: string[];
  filters: string[];
}

interface PaginatedServiceOptions extends BaseServiceOptions {
  paginate: {
    default?: number;
    max?: number
  }
}

interface NoPaginateServiceOptions extends BaseServiceOptions {
  paginate: false
}

export type ServiceOptions = PaginatedServiceOptions | NoPaginateServiceOptions

export class AdapterService<T = any, O extends ServiceOptions = ServiceOptions> implements ServiceMethods<T> {
  options: O;

  constructor (options: Partial<ServiceOptions>) {
    const defaultOpts: ServiceOptions = {
      id: 'id',
      events: [],
      multi: false,
      paginate: {},
      filters: [],
      whitelist: []
    }

    this.options = Object.assign({
      defaultOpts,
      options
    })
  }

  // ...

  find <P extends Params> (params?: P): O extends NoPaginateServiceOptions
    ? Promise<T[]>
    : P extends Params & { paginate: false }
    ? Promise<T[]>
    : Promise<Paginated<T>> {
      return callMethod(this, '_find', params)
  }
 
  // ...
}
```

So anyway, this PR is just the simple version that makes the assumption that pagination is enabled.  The above is included for comment / conversation.