### PR TITLE
fix: independent mode does not interpolate placeholders

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,7 +10,7 @@
     },
     "publish": {
       "allowBranch": "release",
-      "message": "chore(release): publish %s",
+      "message": "chore(release): publish",
       "conventionalCommits": true,
       "createRelease": "github"
     }


### PR DESCRIPTION
> Note that this placeholder interpolation only applies when using the default "fixed" versioning mode, as there is no "global" version to interpolate when versioning independently.